### PR TITLE
changed docs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ case_ending.
 All models config are placed in the config directory.
 
 ```bash
-python train.py --model model_name --config config/config_name.yml
+python train.py --model_kind model_name --config config/config_name.yml
 ```
 
 The model will report the WER and DER while training using the


### PR DESCRIPTION
The `train.py` parser is looking for model_kind rather than model.

![image](https://user-images.githubusercontent.com/57009004/163188125-29f1fc99-a763-4c21-81b3-0cc9de9200f7.png)