### PR TITLE
Removed duplicate keys in seq2seq.yml

### DIFF
--- a/config/seq2seq.yml
+++ b/config/seq2seq.yml
@@ -45,8 +45,6 @@ attention_type: LocationSensitive
 
 use_mixed_precision: false
 optimizer_type: Adam
-text_encoder: ArabicEncoderWithStartSymbol
-text_cleaner: null
 device: cuda
 
 # LOGGING


### PR DESCRIPTION
`text_encoder` and `text_cleaner` are duplicated in seq2seq.yml, which causes an error.